### PR TITLE
Add production docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ Run the application in production mode
 3. Create the tables: `RAILS_ENV=production bin/rake db:migrate`
 4. Run the server: `RAILS_ENV=production bin/rails s`
 
+Run the full app through Docker-Compose for production
+------------------------------------------------------
+
+1. Fill the environment variables in `docker-compose.yml`
+2. Run the containers `docker-compose up`
+3. Access the website with `localhost:8080` or `yourdomain.net:8080`
+
 Run the test
 ------------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3'
+services:
+  cnil-pia-back:
+    image: lrqdo/cnil-pia-back
+    restart: always
+    environment:
+      DATABASE_HOST: 'database'
+      DATABASE_USERNAME: 'postgres'
+      DATABASE_PASSWORD: 'somepassword'
+      SECRET_KEY_BASE: 'somesecret'
+    links:
+      - database
+    depends_on:
+      - database
+    ports:
+      - 3000:3000
+
+  cnil-pia-front:
+    image: lrqdo/cnil-pia-front
+    restart: always
+    ports:
+      - 0.0.0.0:8080:80
+
+  database:
+    restart: always
+    image: postgres:10.1
+    environment:
+      POSTGRES_PASSWORD: 'somepassword'


### PR DESCRIPTION
Add a `docker-compose.yml` file to be used as production.

The best would be to give also the Dockerfiles, by I think it is not the appropriate repository. The CNIL should create a dedicated repository for Docker.